### PR TITLE
Changed links to assets in index.html back to Assets rather than assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-  <link rel="stylesheet" href="./assets/css/style.css" />
+  <link rel="stylesheet" href="./Assets/css/style.css" />
   <title>Password Generator</title>
 </head>
 
@@ -26,7 +26,7 @@
       </div>
     </div>
   </div>
-  <script type="text/javascript" src="./assets/js/script.js"></script>
+  <script type="text/javascript" src="./Assets/js/script.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The original files that I pulled for the assignment had a capitalized A in assets. I tried to change the folder name to a lowercase a but that change didn't cross over to Git Hub so I reverted to Assets to fix the broken deployed page.